### PR TITLE
Fix downloader for current anonymous.4open.science API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,93 @@
 # clone_anonymous_github
 
-clone / download repositories from anonymous.4open.science
+Download repositories from `anonymous.4open.science`.
 
-```
-git clone https://github.com/kynehc/clone_anonymous_github.git
+This fork updates the original script so it works with the current anonymous.4open.science API behavior, especially for repositories with nested directories and many files.
+
+## What this fork fixes
+
+Compared with the earlier script version, this fork now:
+
+- recursively traverses repository directories using the current `files/?path=...` API pattern
+- retries failed requests when the service returns transient network errors
+- backs off and retries when the service returns `429 Too Many Requests`
+- URL-encodes file paths before downloading
+- skips files that are already present locally with the expected size
+- verifies downloaded file size to reduce the chance of keeping partial files
+- uses a lower default concurrency for better stability on large repositories
+
+## Installation
+
+```bash
+git clone https://github.com/wanweilin/clone_anonymous_github.git
 cd clone_anonymous_github
-python download.py --url https://anonymous.4open.science/r/****/ --dir savepath/
+pip install requests
 ```
-pls make sure there is a slash in the end of url.
 
-#### Acknowledgement
+## Basic usage
 
-Thanks to [tdurieux's Anonymous Github project] (https://github.com/tdurieux/anonymous_github)
-and [ShoufaChen's Anonymous Github project] (https://github.com/ShoufaChen/clone-anonymous4open)
+```bash
+python download.py --url https://anonymous.4open.science/r/<repo-id>/ --dir savepath/
+```
+
+Example:
+
+```bash
+python download.py \
+  --url https://anonymous.4open.science/r/TritonDFT-43C7/ \
+  --dir download/TritonDFT-43C7
+```
+
+Important:
+
+- keep the trailing slash at the end of `--url`
+- use a writable output directory for `--dir`
+- if the remote service is unstable, rerun the same command and the script will skip files that were already downloaded successfully
+
+## Arguments
+
+- `--url`: target anonymous repository URL, for example `https://anonymous.4open.science/r/TritonDFT-43C7/`
+- `--dir`: local output directory
+- `--max-conns`: maximum concurrent download workers, default `4`
+
+Example with an explicit worker count:
+
+```bash
+python download.py \
+  --url https://anonymous.4open.science/r/TritonDFT-43C7/ \
+  --dir download/TritonDFT-43C7 \
+  --max-conns 4
+```
+
+## How it works
+
+The script performs the following steps:
+
+1. extract the repository name from the anonymous.4open.science URL
+2. recursively list files using the current API endpoint:
+   - repository root: `/api/repo/<repo>/files/`
+   - subdirectories: `/api/repo/<repo>/files/?path=<subdir>`
+3. build file download URLs with `/api/repo/<repo>/file/<path>`
+4. download files concurrently with retries and backoff
+5. skip already-complete files and verify output sizes
+
+## Notes on reliability
+
+The anonymous.4open.science service may occasionally return:
+
+- SSL EOF / connection reset style failures
+- `429 Too Many Requests`
+- partial transfers on large repositories
+
+This fork adds retry logic and conservative concurrency to make these cases more manageable, but repeated retries may still be needed for very large repositories.
+
+## Limitations
+
+- this script is not a full `git clone`; it downloads the file contents exposed by anonymous.4open.science
+- submodule behavior depends on what the anonymous mirror exposes
+- service-side API changes may require future updates
+
+## Acknowledgement
+
+Thanks to [tdurieux's Anonymous Github project](https://github.com/tdurieux/anonymous_github)
+and [ShoufaChen's Anonymous Github project](https://github.com/ShoufaChen/clone-anonymous4open)

--- a/download.py
+++ b/download.py
@@ -1,86 +1,117 @@
 import argparse
-import requests
+import concurrent.futures
 import os
 from time import sleep
-import concurrent.futures
+from urllib.parse import quote
+
+import requests
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Safari/605.1.15"
+}
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Clone from the https://anonymous.4open.science')
-    parser.add_argument('--dir', type=str, default='master',
-                        help='save dir')
+    parser.add_argument('--dir', type=str, default='master', help='save dir')
     parser.add_argument('--url', type=str,
                         help='target anonymous github link eg., https://anonymous.4open.science/r/840c8c57-3c32-451e-bf12-0e20be300389/')
-    parser.add_argument('--max-conns', type=int, default=128,
-                        help='max connections number')
+    parser.add_argument('--max-conns', type=int, default=4, help='max connections number')
     return parser.parse_args()
 
-def dict_parse(dic, pre=None):
-    pre = pre[:] if pre else []
-    if isinstance(dic, dict):
-        for key, value in dic.items():
-            if isinstance(value, dict):
-                for d in dict_parse(value, pre + [key]):
-                    yield d
-            else:
-                yield pre + [key, value]
-    else:
-        yield pre + [dic]
 
-def req_url(dl_file, max_retry=5):
-    url = dl_file[0]
-    save_path = dl_file[1]
-    save_dir = '/'.join(save_path.split('/')[:-1])
-    if not os.path.exists(save_dir) and save_dir:
-        try:
-            os.makedirs(save_dir)
-        except OSError:
-            pass
-    
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Safari/605.1.15"
-    }
+def request_with_retry(url, params=None, max_retry=8, timeout=60):
+    last_exc = None
     for i in range(max_retry):
         try:
-            r = requests.get(url, headers=headers)
-            with open(save_path, "wb") as f:
-                f.write(r.content)
-            return
+            resp = requests.get(url, headers=HEADERS, params=params, timeout=timeout)
+            if resp.status_code == 429:
+                retry_after = resp.headers.get('Retry-After')
+                sleep(float(retry_after) if retry_after else min(2 ** i, 10))
+                continue
+            resp.raise_for_status()
+            return resp
+        except requests.RequestException as exc:
+            last_exc = exc
+            sleep(min(2 ** i, 10))
+    raise last_exc
+
+
+def fetch_file_list(repo_name):
+    list_url = f"https://anonymous.4open.science/api/repo/{repo_name}/files/"
+    pending_dirs = ['']
+    visited_dirs = set()
+    files = []
+
+    while pending_dirs:
+        current_dir = pending_dirs.pop()
+        if current_dir in visited_dirs:
+            continue
+        visited_dirs.add(current_dir)
+
+        params = {'path': current_dir} if current_dir else None
+        resp = request_with_retry(list_url, params=params)
+
+        for entry in resp.json():
+            entry_path = os.path.join(entry.get('path', ''), entry['name']).replace('\\', '/')
+            if 'size' in entry:
+                files.append((entry_path, entry['size']))
+            else:
+                pending_dirs.append(entry_path)
+
+    return files
+
+
+def req_url(dl_file, max_retry=8):
+    url, save_path, expected_size = dl_file
+    save_dir = os.path.dirname(save_path)
+    if save_dir and not os.path.exists(save_dir):
+        os.makedirs(save_dir, exist_ok=True)
+
+    if os.path.exists(save_path) and os.path.getsize(save_path) == expected_size:
+        return 'skipped'
+
+    last_exc = None
+    for i in range(max_retry):
+        try:
+            resp = request_with_retry(url, max_retry=max_retry)
+            with open(save_path, 'wb') as f:
+                f.write(resp.content)
+            if os.path.getsize(save_path) != expected_size:
+                raise IOError(f'size mismatch: expected {expected_size}, got {os.path.getsize(save_path)}')
+            return 'downloaded'
         except Exception as e:
+            last_exc = e
             print('file request exception (retry {}): {} - {}'.format(i, e, save_path))
-            sleep(0.4)
+            sleep(min(2 ** i, 10))
+
+    raise last_exc
 
 
 if __name__ == '__main__':
     args = parse_args()
-    assert args.url, '\nPlese specifipy your target anonymous github link, \n e.g:    '\
-            +'python download.py --target https://anonymous.4open.science/r/840c8c57-3c32-451e-bf12-0e20be300389/'
-    
+    assert args.url, '\nPlese specifipy your target anonymous github link, \n e.g:    ' \
+            + 'python download.py --target https://anonymous.4open.science/r/840c8c57-3c32-451e-bf12-0e20be300389/'
+
     url = args.url
     name = url.split('/')[-2]
     max_conns = args.max_conns
 
-    print("[*] cloning project:" + name)
-    
-    list_url = "https://anonymous.4open.science/api/repo/"+ name +"/files/"
-    headers = {
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Safari/605.1.15"
-    }
-    resp = requests.get(url=list_url, headers=headers)
-    file_list = resp.json()
+    print('[*] cloning project:' + name)
+    file_list = fetch_file_list(name)
 
-    print("[*] downloading files:")
-    
-    dl_url = "https://anonymous.4open.science/api/repo/"+ name +"/file/"
+    print('[*] downloading files:')
+
+    dl_url = f"https://anonymous.4open.science/api/repo/{name}/file/"
     files = []
     out = []
-    for file in dict_parse(file_list):
-        file_path = os.path.join(*file[-len(file):-2]) # * operator to unpack the arguments out of a list
+    for file_path, expected_size in file_list:
         save_path = os.path.join(args.dir, file_path)
-        file_url = dl_url + file_path
-        files.append((file_url, save_path))
-    
+        file_url = dl_url + quote(file_path, safe='/')
+        files.append((file_url, save_path, expected_size))
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_conns) as executor:
-        future_to_url = (executor.submit(req_url, dl_file) for dl_file in files)
+        future_to_url = [executor.submit(req_url, dl_file) for dl_file in files]
         for future in concurrent.futures.as_completed(future_to_url):
             try:
                 data = future.result()
@@ -88,7 +119,6 @@ if __name__ == '__main__':
                 data = str(type(exc))
             finally:
                 out.append(data)
+                print(str(len(out)), end='\r')
 
-                print(str(len(out)),end="\r")
-    
-    print("[*] files saved to:" + args.dir)
+    print('[*] files saved to:' + args.dir)


### PR DESCRIPTION
## Summary
  - update `download.py` to work with the current anonymous.4open.science listing API
  - add retries, rate-limit backoff, and file-size verification for more reliable downloads
  - expand the README with setup, usage examples, reliability notes, and limitations

  ## Test plan
  - [x] download a real anonymous repository with nested directories
  - [x] verify recursive listing works with the current `files/?path=...` API behavior
  - [x] confirm rerunning the command skips already completed files
  - [x] verify the downloaded file set matches the expected remote file list